### PR TITLE
Adding information in problems

### DIFF
--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/controller/ProblemController.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/controller/ProblemController.java
@@ -5,6 +5,7 @@ import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.service.ProblemService;
 import com.bspq26e8.backend.problem.service.ProblemService.CreateProblemCommand;
 import com.bspq26e8.backend.problem.service.ProblemService.CreateProblemResult;
+import com.bspq26e8.backend.problem.service.ProblemService.ProblemDetail;
 import com.bspq26e8.backend.problem.service.ProblemService.ProblemSummary;
 import com.bspq26e8.backend.problem.service.ProblemService.UpdateProblemCommand;
 import com.bspq26e8.backend.problem.service.ProblemService.UpdateProblemResult;
@@ -126,6 +127,15 @@ public class ProblemController {
 		}
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/{problemId}")
+	public ResponseEntity<?> getProblemDetail(@PathVariable UUID problemId) {
+		Optional<ProblemDetail> detail = problemService.getProblemDetail(problemId);
+		if (detail.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error("Problem not found"));
+		}
+		return ResponseEntity.ok(detail.get());
 	}
 
 	@GetMapping("/by-author/{authorId}")

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/Problem.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/Problem.java
@@ -156,6 +156,10 @@ public class Problem {
         return createdAt;
     }
 
+    public List<TestCase> getTestCases() {
+        return testCases;
+    }
+
     public void updateEditableFields(
             String slug,
             String title,

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/TestCase.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/TestCase.java
@@ -26,8 +26,15 @@ public class TestCase {
     @Column(nullable = false)
     private boolean isSample = false;
 
+    public String getInputData() {
+        return inputData;
+    }
 
+    public String getExpectedOutput() {
+        return expectedOutput;
+    }
 
-
-
+    public boolean isSample() {
+        return isSample;
+    }
 }

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
@@ -2,6 +2,7 @@ package com.bspq26e8.backend.problem.service;
 
 import com.bspq26e8.backend.problem.entity.Problem;
 import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
+import com.bspq26e8.backend.problem.entity.TestCase;
 import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
 import com.bspq26e8.backend.user.entity.User;
@@ -14,6 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ProblemService {
@@ -116,6 +118,42 @@ public class ProblemService {
 		List<String> languages = resolveLanguagesByProblemIds(List.of(saved.getId()))
 				.getOrDefault(saved.getId(), List.of());
 		return UpdateProblemResult.updated(toSummary(saved, languages));
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<ProblemDetail> getProblemDetail(UUID problemId) {
+		Optional<Problem> maybeProblem = problemRepository.findById(problemId);
+		if (maybeProblem.isEmpty()) {
+			return Optional.empty();
+		}
+
+		Problem problem = maybeProblem.get();
+		List<String> languages = resolveLanguagesByProblemIds(List.of(problem.getId()))
+				.getOrDefault(problem.getId(), List.of());
+
+		List<SampleTestCase> examples = problem.getTestCases() == null ? List.of() :
+				problem.getTestCases().stream()
+						.filter(TestCase::isSample)
+						.map(tc -> new SampleTestCase(tc.getInputData(), tc.getExpectedOutput()))
+						.toList();
+
+		UUID authorId = problem.getAuthor() == null ? null : problem.getAuthor().getId();
+
+		return Optional.of(new ProblemDetail(
+				problem.getId(),
+				problem.getSlug(),
+				problem.getTitle(),
+				problem.getDifficulty(),
+				authorId,
+				problem.getCreatedAt(),
+				languages,
+				problem.getStatementMd(),
+				problem.getInputSpecMd(),
+				problem.getOutputSpecMd(),
+				problem.getConstraintsMd(),
+				problem.getHintsMd(),
+				examples
+		));
 	}
 
 	public Optional<DeleteProblemError> deleteProblemByAuthor(UUID problemId, UUID authorId) {
@@ -224,6 +262,25 @@ public class ProblemService {
 			UUID authorId,
 			java.time.OffsetDateTime createdAt,
 			List<String> languages
+	) {
+	}
+
+	public record SampleTestCase(String inputData, String expectedOutput) {}
+
+	public record ProblemDetail(
+			UUID id,
+			String slug,
+			String title,
+			ProblemDifficulty difficulty,
+			UUID authorId,
+			java.time.OffsetDateTime createdAt,
+			List<String> languages,
+			String statementMd,
+			String inputSpecMd,
+			String outputSpecMd,
+			String constraintsMd,
+			String hintsMd,
+			List<SampleTestCase> examples
 	) {
 	}
 

--- a/src/frontend/css/problems.css
+++ b/src/frontend/css/problems.css
@@ -94,7 +94,7 @@
   flex-direction: column;
   gap: 0.75rem;
   min-height: 154px;
-  cursor: default;
+  cursor: pointer;
   border-radius: 10px;
   background: rgba(37, 40, 54, 0.36);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -158,6 +158,159 @@
   font-family: var(--font-mono);
   color: rgba(148, 163, 184, 0.42);
   font-size: 0.72rem;
+}
+
+/* ── Card toggle arrow */
+.problem-card-top {
+  align-items: flex-start;
+}
+
+.problem-card-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(148, 163, 184, 0.5);
+  font-size: 0.65rem;
+  transition: transform 0.25s ease, color var(--transition);
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  user-select: none;
+}
+
+.problem-card.is-expanded .problem-card-toggle {
+  transform: rotate(180deg);
+  color: var(--accent-light);
+}
+
+/* ── Expanded card state */
+.problem-card.is-expanded {
+  transform: none;
+  border-color: rgba(108, 99, 255, 0.35);
+  box-shadow: 0 0 0 1px rgba(108, 99, 255, 0.18), 0 16px 40px rgba(10, 12, 18, 0.4);
+}
+
+.problem-card.is-expanded:hover {
+  transform: none;
+}
+
+/* ── Detail panel */
+.problem-detail {
+  display: none;
+  flex-direction: column;
+  gap: 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  padding-top: 1.25rem;
+  margin-top: 0.25rem;
+}
+
+.problem-detail.is-open {
+  display: flex;
+}
+
+/* ── Detail sections */
+.problem-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.problem-detail-section-title {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--accent-light);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.problem-detail-section-body {
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+  color: var(--text-mid);
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+/* ── Examples */
+.problem-detail-examples {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.problem-detail-example {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.problem-detail-example-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.problem-detail-example-label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.problem-detail-example-code {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text);
+  background: rgba(15, 17, 23, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.55rem 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Start Coding button */
+.problem-detail-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.problem-detail-start-btn {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--white);
+  background: var(--accent);
+  border: none;
+  border-radius: 5px;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  transition: background var(--transition), transform 0.15s, box-shadow var(--transition);
+}
+
+.problem-detail-start-btn:hover {
+  background: var(--accent-light);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(108, 99, 255, 0.35);
+}
+
+/* ── Detail loading / error */
+.problem-detail-loading {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  padding: 0.5rem 0;
+}
+
+.problem-detail-error {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--red);
+  padding: 0.5rem 0;
 }
 
 /* ── Status messages */

--- a/src/frontend/js/problems.js
+++ b/src/frontend/js/problems.js
@@ -32,6 +32,8 @@
     loadedProblems: [],
   };
 
+  const detailCache = new Map();
+
   let searchTimer = null;
 
   function setStatus(message, isError = false) {
@@ -126,6 +128,96 @@
     return sorted;
   }
 
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function buildDetailSection(title, body) {
+    return `
+      <div class="problem-detail-section">
+        <span class="problem-detail-section-title">${title}</span>
+        <p class="problem-detail-section-body">${escapeHtml(body)}</p>
+      </div>`;
+  }
+
+  function renderDetail(detailEl, data) {
+    const sections = [];
+
+    if (data.statementMd) sections.push(buildDetailSection('Problem Statement', data.statementMd));
+    if (data.inputSpecMd) sections.push(buildDetailSection('Input', data.inputSpecMd));
+    if (data.outputSpecMd) sections.push(buildDetailSection('Output', data.outputSpecMd));
+    if (data.constraintsMd) sections.push(buildDetailSection('Constraints', data.constraintsMd));
+    if (data.hintsMd) sections.push(buildDetailSection('Hints', data.hintsMd));
+
+    let examplesHtml = '';
+    if (Array.isArray(data.examples) && data.examples.length > 0) {
+      const items = data.examples.map((ex) => `
+        <div class="problem-detail-example">
+          <div class="problem-detail-example-block">
+            <span class="problem-detail-example-label">Input</span>
+            <pre class="problem-detail-example-code">${escapeHtml(ex.inputData || '')}</pre>
+          </div>
+          <div class="problem-detail-example-block">
+            <span class="problem-detail-example-label">Output</span>
+            <pre class="problem-detail-example-code">${escapeHtml(ex.expectedOutput || '')}</pre>
+          </div>
+        </div>`).join('');
+      examplesHtml = `
+        <div class="problem-detail-section">
+          <span class="problem-detail-section-title">Examples</span>
+          <div class="problem-detail-examples">${items}</div>
+        </div>`;
+    }
+
+    detailEl.innerHTML = `
+      ${sections.join('')}
+      ${examplesHtml}
+      <div class="problem-detail-footer">
+        <button type="button" class="problem-detail-start-btn">Start Coding</button>
+      </div>`;
+
+    detailEl.querySelector('.problem-detail-start-btn').addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+  }
+
+  async function toggleDetail(card, problem) {
+    const detailEl = card.querySelector('.problem-detail');
+
+    if (card.classList.contains('is-expanded')) {
+      card.classList.remove('is-expanded');
+      detailEl.classList.remove('is-open');
+      return;
+    }
+
+    card.classList.add('is-expanded');
+    detailEl.classList.add('is-open');
+
+    if (detailCache.has(problem.id)) {
+      renderDetail(detailEl, detailCache.get(problem.id));
+      return;
+    }
+
+    detailEl.innerHTML = '<p class="problem-detail-loading">Loading...</p>';
+
+    try {
+      const response = await fetch(`${API_BASE}/api/problems/${problem.id}`);
+      if (!response.ok) {
+        detailEl.innerHTML = '<p class="problem-detail-error">Could not load problem details.</p>';
+        return;
+      }
+      const data = await response.json();
+      detailCache.set(problem.id, data);
+      renderDetail(detailEl, data);
+    } catch (err) {
+      detailEl.innerHTML = '<p class="problem-detail-error">Could not reach the server.</p>';
+    }
+  }
+
   function buildCard(problem) {
     const diff = DIFFICULTY[problem.difficulty] || DIFFICULTY.EASY;
     const safeSlug = problem.slug || 'no-slug';
@@ -137,13 +229,18 @@
     card.innerHTML = `
       <div class="problem-card-top">
         <span class="problem-card-slug">${safeSlug}</span>
-        <span class="badge ${diff.badge}">${diff.label}</span>
+        <div style="display:flex;align-items:center;gap:0.6rem">
+          <span class="badge ${diff.badge}">${diff.label}</span>
+          <span class="problem-card-toggle">▼</span>
+        </div>
       </div>
       <p class="problem-card-title">${safeTitle}</p>
       <p class="problem-card-language">${formatLanguages(problem.languages)}</p>
       <p class="problem-card-meta">${formatCreatedAt(problem.createdAt)}</p>
+      <div class="problem-detail"></div>
     `;
 
+    card.addEventListener('click', () => toggleDetail(card, problem));
     return card;
   }
 


### PR DESCRIPTION
Added a clickable expandable panel to each problem card that fetches and displays the full problem details (statement, input/output specs, constraints, hints and examples) from a new GET /api/problems/{id} endpoint. A "Start Coding" button is included at the bottom of the panel, ready to be wired up in a future iteration.