### PR TITLE
Implement access token secret configuration and update tests (#71)

### DIFF
--- a/src/backend/src/main/java/com/bspq26e8/backend/auth/security/AccessTokenService.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/auth/security/AccessTokenService.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,7 +17,13 @@ public class AccessTokenService {
 
     private static final String HMAC_SHA256 = "HmacSHA256";
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final String TOKEN_SECRET = "bspq26e8-dev-access-token-secret";
+    private final String tokenSecret;
+
+    public AccessTokenService(
+            @Value("${security.access-token.secret:bspq26e8-dev-access-token-secret}") String tokenSecret
+    ) {
+        this.tokenSecret = tokenSecret;
+    }
 
     public String generateAccessToken(UUID userId) {
         String payload = userId + ":" + Instant.now().getEpochSecond();
@@ -71,7 +78,7 @@ public class AccessTokenService {
     private byte[] hmacSha256(String data) {
         try {
             Mac mac = Mac.getInstance(HMAC_SHA256);
-            SecretKeySpec secretKeySpec = new SecretKeySpec(TOKEN_SECRET.getBytes(StandardCharsets.UTF_8), HMAC_SHA256);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(tokenSecret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256);
             mac.init(secretKeySpec);
             return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
         } catch (NoSuchAlgorithmException | InvalidKeyException ex) {

--- a/src/backend/src/main/resources/application.yml
+++ b/src/backend/src/main/resources/application.yml
@@ -25,3 +25,7 @@ spring:
   sql:
     init:
       mode: never
+
+security:
+  access-token:
+    secret: ${ACCESS_TOKEN_SECRET:bspq26e8-dev-access-token-secret}

--- a/src/backend/src/test/java/com/bspq26e8/backend/auth/security/AccessTokenServiceTest.java
+++ b/src/backend/src/test/java/com/bspq26e8/backend/auth/security/AccessTokenServiceTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AccessTokenServiceTest {
 
-    private final AccessTokenService accessTokenService = new AccessTokenService();
+    private final AccessTokenService accessTokenService = new AccessTokenService("test-access-token-secret");
 
     @Test
     void generateAccessTokenAndExtractUserId() {

--- a/src/backend/src/test/java/com/bspq26e8/backend/problem/service/ProblemServiceTest.java
+++ b/src/backend/src/test/java/com/bspq26e8/backend/problem/service/ProblemServiceTest.java
@@ -5,6 +5,7 @@ import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
 import com.bspq26e8.backend.user.entity.User;
 import com.bspq26e8.backend.user.repository.UserRepository;
+import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,6 +30,9 @@ public class ProblemServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ProblemLanguageRepository problemLanguageRepository;
 
     @InjectMocks
     private ProblemService problemService;


### PR DESCRIPTION
This pull request improves the security and configurability of the access token generation logic by making the secret key externally configurable instead of hardcoded. The changes also update the tests and configuration files to support this enhancement.