### PR TITLE
fix: examples from create form now saved and shown in problem preview

### DIFF
--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/controller/ProblemController.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/controller/ProblemController.java
@@ -5,6 +5,7 @@ import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.service.ProblemService;
 import com.bspq26e8.backend.problem.service.ProblemService.CreateProblemCommand;
 import com.bspq26e8.backend.problem.service.ProblemService.CreateProblemResult;
+import com.bspq26e8.backend.problem.service.ProblemService.ExampleInput;
 import com.bspq26e8.backend.problem.service.ProblemService.ProblemDetail;
 import com.bspq26e8.backend.problem.service.ProblemService.ProblemSummary;
 import com.bspq26e8.backend.problem.service.ProblemService.UpdateProblemCommand;
@@ -67,6 +68,14 @@ public class ProblemController {
 			return ResponseEntity.badRequest().body(error("Invalid slug format"));
 		}
 
+		List<ExampleInput> examples = request.examples() == null ? List.of() :
+				request.examples().stream()
+						.filter(ex -> ex != null && ex.inputData() != null && !ex.inputData().isBlank())
+						.map(ex -> new ExampleInput(
+								ex.inputData().trim(),
+								ex.expectedOutput() == null ? "" : ex.expectedOutput().trim()))
+						.toList();
+
 		CreateProblemCommand command = new CreateProblemCommand(
 				slug,
 				title,
@@ -78,7 +87,8 @@ public class ProblemController {
 				difficulty.get(),
 				authenticatedUserId.get(),
 				normalizeOptionalText(request.solutionTemplate()),
-				normalizeJsonConfig(request.languageCompilationConfig())
+				normalizeJsonConfig(request.languageCompilationConfig()),
+				examples
 		);
 
 		CreateProblemResult result = problemService.createProblem(command);
@@ -248,7 +258,8 @@ public class ProblemController {
 			String hintsMd,
 			String difficulty,
 			String solutionTemplate,
-			String languageCompilationConfig
+			String languageCompilationConfig,
+			List<ExampleInput> examples
 	) {
 	}
 

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/Problem.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/Problem.java
@@ -160,6 +160,10 @@ public class Problem {
         return testCases;
     }
 
+    public void setTestCases(List<TestCase> testCases) {
+        this.testCases = testCases;
+    }
+
     public void updateEditableFields(
             String slug,
             String title,

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/TestCase.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/TestCase.java
@@ -43,4 +43,11 @@ public class TestCase {
     public boolean isSample() {
         return isSample;
     }
+
+    public TestCase(Problem problem, String inputData, String expectedOutput, boolean isSample) {
+        this.problem = problem;
+        this.inputData = inputData;
+        this.expectedOutput = expectedOutput;
+        this.isSample = isSample;
+    }
 }

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/repository/TestCaseRepository.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/repository/TestCaseRepository.java
@@ -1,0 +1,9 @@
+package com.bspq26e8.backend.problem.repository;
+
+import com.bspq26e8.backend.problem.entity.TestCase;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TestCaseRepository extends JpaRepository<TestCase, UUID> {
+}

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/repository/TestCaseRepository.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/repository/TestCaseRepository.java
@@ -1,9 +1,0 @@
-package com.bspq26e8.backend.problem.repository;
-
-import com.bspq26e8.backend.problem.entity.TestCase;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.UUID;
-
-public interface TestCaseRepository extends JpaRepository<TestCase, UUID> {
-}

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
@@ -5,6 +5,7 @@ import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.entity.TestCase;
 import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
+import com.bspq26e8.backend.problem.repository.TestCaseRepository;
 import com.bspq26e8.backend.user.entity.User;
 import com.bspq26e8.backend.user.repository.UserRepository;
 import java.util.Collection;
@@ -23,17 +24,21 @@ public class ProblemService {
 	private final ProblemRepository problemRepository;
 	private final ProblemLanguageRepository problemLanguageRepository;
 	private final UserRepository userRepository;
+	private final TestCaseRepository testCaseRepository;
 
 	public ProblemService(
 			ProblemRepository problemRepository,
 			ProblemLanguageRepository problemLanguageRepository,
-			UserRepository userRepository
+			UserRepository userRepository,
+			TestCaseRepository testCaseRepository
 	) {
 		this.problemRepository = problemRepository;
 		this.problemLanguageRepository = problemLanguageRepository;
 		this.userRepository = userRepository;
+		this.testCaseRepository = testCaseRepository;
 	}
 
+	@Transactional
 	public CreateProblemResult createProblem(CreateProblemCommand command) {
 		if (problemRepository.existsBySlug(command.slug())) {
 			return CreateProblemResult.conflict("A problem with that slug already exists");
@@ -60,6 +65,19 @@ public class ProblemService {
 		);
 
 		Problem saved = problemRepository.save(problem);
+
+		if (command.examples() != null && !command.examples().isEmpty()) {
+			List<TestCase> sampleCases = command.examples().stream()
+					.filter(ex -> ex.inputData() != null && !ex.inputData().isBlank())
+					.map(ex -> new TestCase(
+							saved,
+							ex.inputData().trim(),
+							ex.expectedOutput() == null ? "" : ex.expectedOutput().trim(),
+							true))
+					.toList();
+			testCaseRepository.saveAll(sampleCases);
+		}
+
 		List<String> languages = resolveLanguagesByProblemIds(List.of(saved.getId()))
 				.getOrDefault(saved.getId(), List.of());
 		return CreateProblemResult.created(toSummary(saved, languages));
@@ -239,6 +257,8 @@ public class ProblemService {
 		);
 	}
 
+	public record ExampleInput(String inputData, String expectedOutput) {}
+
 	public record CreateProblemCommand(
 			String slug,
 			String title,
@@ -250,7 +270,8 @@ public class ProblemService {
 			ProblemDifficulty difficulty,
 			UUID authorId,
 			String solutionTemplate,
-			String languageCompilationConfig
+			String languageCompilationConfig,
+			List<ExampleInput> examples
 	) {
 	}
 

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
@@ -5,7 +5,6 @@ import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.entity.TestCase;
 import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
-import com.bspq26e8.backend.problem.repository.TestCaseRepository;
 import com.bspq26e8.backend.user.entity.User;
 import com.bspq26e8.backend.user.repository.UserRepository;
 import java.util.Collection;
@@ -24,18 +23,15 @@ public class ProblemService {
 	private final ProblemRepository problemRepository;
 	private final ProblemLanguageRepository problemLanguageRepository;
 	private final UserRepository userRepository;
-	private final TestCaseRepository testCaseRepository;
 
 	public ProblemService(
 			ProblemRepository problemRepository,
 			ProblemLanguageRepository problemLanguageRepository,
-			UserRepository userRepository,
-			TestCaseRepository testCaseRepository
+			UserRepository userRepository
 	) {
 		this.problemRepository = problemRepository;
 		this.problemLanguageRepository = problemLanguageRepository;
 		this.userRepository = userRepository;
-		this.testCaseRepository = testCaseRepository;
 	}
 
 	@Transactional
@@ -64,19 +60,19 @@ public class ProblemService {
 				command.languageCompilationConfig()
 		);
 
-		Problem saved = problemRepository.save(problem);
-
 		if (command.examples() != null && !command.examples().isEmpty()) {
 			List<TestCase> sampleCases = command.examples().stream()
 					.filter(ex -> ex.inputData() != null && !ex.inputData().isBlank())
 					.map(ex -> new TestCase(
-							saved,
+							problem,
 							ex.inputData().trim(),
 							ex.expectedOutput() == null ? "" : ex.expectedOutput().trim(),
 							true))
 					.toList();
-			testCaseRepository.saveAll(sampleCases);
+			problem.setTestCases(sampleCases);
 		}
+
+		Problem saved = problemRepository.save(problem);
 
 		List<String> languages = resolveLanguagesByProblemIds(List.of(saved.getId()))
 				.getOrDefault(saved.getId(), List.of());

--- a/src/backend/src/test/java/com/bspq26e8/backend/problem/service/ProblemServiceTest.java
+++ b/src/backend/src/test/java/com/bspq26e8/backend/problem/service/ProblemServiceTest.java
@@ -4,6 +4,7 @@ import com.bspq26e8.backend.problem.entity.Problem;
 import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
+import com.bspq26e8.backend.problem.repository.TestCaseRepository;
 import com.bspq26e8.backend.user.entity.User;
 import com.bspq26e8.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,9 +31,10 @@ public class ProblemServiceTest {
     private ProblemLanguageRepository problemLanguageRepository;
     @Mock
     private ProblemRepository problemRepository;
-
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private TestCaseRepository testCaseRepository;
 
     @InjectMocks
     private ProblemService problemService;
@@ -46,7 +48,7 @@ public class ProblemServiceTest {
     void createProblem_Success() {
         ProblemService.CreateProblemCommand command = new ProblemService.CreateProblemCommand(
                 "test-slug", "Test Title", "statement", "input", "output", "constraints", "hints",
-                ProblemDifficulty.EASY, UUID.randomUUID(), "template", "config"
+                ProblemDifficulty.EASY, UUID.randomUUID(), "template", "config", List.of()
         );
         User mockUser = mock(User.class);
         when(userRepository.findById(command.authorId())).thenReturn(Optional.of(mockUser));
@@ -79,7 +81,7 @@ public class ProblemServiceTest {
     void createProblem_AuthorNotFound() {
         ProblemService.CreateProblemCommand command = new ProblemService.CreateProblemCommand(
                 "test-slug", "Test Title", "statement", "input", "output", "constraints", "hints",
-                ProblemDifficulty.EASY, UUID.randomUUID(), "template", "config"
+                ProblemDifficulty.EASY, UUID.randomUUID(), "template", "config", List.of()
         );
         when(problemRepository.existsBySlug(command.slug())).thenReturn(false);
         when(userRepository.findById(command.authorId())).thenReturn(Optional.empty());
@@ -97,7 +99,7 @@ public class ProblemServiceTest {
     void createProblem_NullAuthorId() {
         ProblemService.CreateProblemCommand command = new ProblemService.CreateProblemCommand(
                 "test-slug", "Test Title", "statement", "input", "output", "constraints", "hints",
-                ProblemDifficulty.EASY, null, "template", "config"
+                ProblemDifficulty.EASY, null, "template", "config", List.of()
         );
         when(problemRepository.existsBySlug(command.slug())).thenReturn(false);
 

--- a/src/backend/src/test/java/com/bspq26e8/backend/problem/service/ProblemServiceTest.java
+++ b/src/backend/src/test/java/com/bspq26e8/backend/problem/service/ProblemServiceTest.java
@@ -4,7 +4,6 @@ import com.bspq26e8.backend.problem.entity.Problem;
 import com.bspq26e8.backend.problem.entity.ProblemDifficulty;
 import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
-import com.bspq26e8.backend.problem.repository.TestCaseRepository;
 import com.bspq26e8.backend.user.entity.User;
 import com.bspq26e8.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,10 +30,9 @@ public class ProblemServiceTest {
     private ProblemLanguageRepository problemLanguageRepository;
     @Mock
     private ProblemRepository problemRepository;
+
     @Mock
     private UserRepository userRepository;
-    @Mock
-    private TestCaseRepository testCaseRepository;
 
     @InjectMocks
     private ProblemService problemService;

--- a/src/frontend/create.html
+++ b/src/frontend/create.html
@@ -48,17 +48,19 @@
         <div class="card">
           <div class="section-header">
             <h3 class="section-title">Examples</h3>
-            <button type="button" class="btn-secondary btn-sm">+ Add</button>
+            <button type="button" class="btn-secondary btn-sm" id="examples-add-btn">+ Add</button>
           </div>
-          <div class="example-box">
-            <div class="form-group">
-              <input class="form-input" type="text" placeholder="Input (e.g. nums = [2,7,11,15], target = 9)" />
-            </div>
-            <div class="form-group">
-              <input class="form-input" type="text" placeholder="Output (e.g. [0,1])" />
-            </div>
-            <div class="form-group">
-              <input class="form-input" type="text" placeholder="Explanation (optional)" />
+          <div id="examples-container">
+            <div class="example-box" data-example>
+              <div class="form-group">
+                <input class="form-input" type="text" data-example-input placeholder="Input (e.g. nums = [2,7,11,15], target = 9)" />
+              </div>
+              <div class="form-group">
+                <input class="form-input" type="text" data-example-output placeholder="Output (e.g. [0,1])" />
+              </div>
+              <div class="form-group">
+                <input class="form-input" type="text" data-example-explanation placeholder="Explanation (optional)" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/frontend/js/create.js
+++ b/src/frontend/js/create.js
@@ -39,6 +39,45 @@
     return val === '' ? null : val;
   }
 
+  /** Builds a new example block element */
+  function buildExampleBlock() {
+    const block = document.createElement('div');
+    block.className = 'example-box';
+    block.dataset.example = '';
+    block.innerHTML = `
+      <div class="form-group">
+        <input class="form-input" type="text" data-example-input placeholder="Input (e.g. nums = [2,7,11,15], target = 9)" />
+      </div>
+      <div class="form-group">
+        <input class="form-input" type="text" data-example-output placeholder="Output (e.g. [0,1])" />
+      </div>
+      <div class="form-group">
+        <input class="form-input" type="text" data-example-explanation placeholder="Explanation (optional)" />
+      </div>
+    `;
+    return block;
+  }
+
+  /** Collects all filled-in examples from the examples container */
+  function collectExamples() {
+    const container = document.getElementById('examples-container');
+    if (!container) return [];
+    return Array.from(container.querySelectorAll('[data-example]'))
+      .map((block) => ({
+        inputData: (block.querySelector('[data-example-input]')?.value || '').trim(),
+        expectedOutput: (block.querySelector('[data-example-output]')?.value || '').trim(),
+      }))
+      .filter((ex) => ex.inputData.length > 0);
+  }
+
+  /** Wires up the "+ Add" button for the examples section */
+  function initExamples() {
+    const container = document.getElementById('examples-container');
+    const addBtn = document.getElementById('examples-add-btn');
+    if (!container || !addBtn) return;
+    addBtn.addEventListener('click', () => container.appendChild(buildExampleBlock()));
+  }
+
   function showStatus(element, message, type) {
     element.textContent = message;
     element.dataset.status = type; // 'success' | 'error'
@@ -86,6 +125,7 @@
       hintsMd:                  field('hintsMd'),
       solutionTemplate:         field('solutionTemplate'),
       languageCompilationConfig: field('languageCompilationConfig'),
+      examples:                 collectExamples(),
     };
 
     submitBtn.disabled = true;
@@ -114,6 +154,7 @@
 
   document.addEventListener('DOMContentLoaded', function () {
     auth.requireAuth(); // redirects to login.html if no token
+    initExamples();
     const form = document.getElementById('create-form');
     if (form) {
       form.addEventListener('submit', submitCreateProblem);


### PR DESCRIPTION
## Problem
When creating a problem, the examples filled in the form were never 
saved to the database, so they didn't appear in the problem preview.

## Solution
- Accept examples list in the create problem API request
- Save examples as sample TestCases using JPA cascade
- Wire up the examples section in the create form (add IDs and 
  data-attributes, collect values on submit)
- The "+ Add" button now works to add multiple examples