### PR TITLE
Playwright acceptance test on CRUD operations

### DIFF
--- a/src/frontend/tests/create-problem.spec.js
+++ b/src/frontend/tests/create-problem.spec.js
@@ -277,6 +277,90 @@ test.describe('Problem creation flow', () => {
     await expect(badges.nth(2)).toHaveClass(/badge--hard/);
   });
 
+  test('sends the exact field values typed into the form to the API', async ({ page }) => {
+    await setupAuth(page);
+
+    /** @type {any} */
+    let capturedBody = null;
+    await page.route('http://localhost:10000/api/problems**', async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        capturedBody = JSON.parse(request.postData() || '{}');
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ ...capturedBody, id: 'id-1', createdAt: '2026-01-01T00:00:00Z' }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    });
+
+    await page.goto(pages.create);
+    await page.fill('#title',            'Two Sum');
+    await page.fill('#statementMd',      'Given an array of integers, return indices of the two numbers that add up to a target.');
+    await page.fill('#constraintsMd',    '2 <= nums.length <= 10^4');
+    await page.fill('#solutionTemplate', 'def two_sum(nums, target):\n    pass');
+    await page.selectOption('#difficulty', 'EASY');
+    await page.click('#submit-btn');
+
+    await expect(page.locator('#status-message')).toHaveAttribute('data-status', 'success');
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody.title).toBe('Two Sum');
+    expect(capturedBody.statementMd).toBe('Given an array of integers, return indices of the two numbers that add up to a target.');
+    expect(capturedBody.constraintsMd).toBe('2 <= nums.length <= 10^4');
+    expect(capturedBody.solutionTemplate).toBe('def two_sum(nums, target):\n    pass');
+    expect(capturedBody.difficulty).toBe('EASY');
+
+    // Fields that have no input element in create.html are submitted as null
+    expect(capturedBody.slug).toBeNull();
+    expect(capturedBody.inputSpecMd).toBeNull();
+    expect(capturedBody.outputSpecMd).toBeNull();
+    expect(capturedBody.hintsMd).toBeNull();
+    expect(capturedBody.languageCompilationConfig).toBeNull();
+  });
+
+  test('card and detail panel display the same values the user submitted', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page);
+
+    const submitted = {
+      title:         'Longest Common Subsequence',
+      statementMd:   'Given two strings text1 and text2, return the length of their longest common subsequence.',
+      constraintsMd: '1 <= text1.length, text2.length <= 1000',
+      /** @type {'MEDIUM'} */
+      difficulty:    'MEDIUM',
+    };
+
+    await page.goto(pages.create);
+    await createProblem(page, submitted);
+
+    await page.goto(pages.problems);
+
+    // ── Card surface reflects title, language, and difficulty styling ─────
+    const card = page.locator('.problem-card');
+    await expect(card).toHaveCount(1);
+    await expect(card.locator('.problem-card-title')).toHaveText(submitted.title);
+    await expect(card.locator('.problem-card-language')).toHaveText('Language: Python 3');
+    await expect(card.locator('.badge')).toHaveClass(/badge--medium/);
+    await expect(card).toHaveClass(/card--orange/);
+
+    // ── Detail surface reflects the markdown body fields ──────────────────
+    await card.click();
+    const detail = card.locator('.problem-detail');
+    await expect(detail).toHaveClass(/is-open/);
+    await expect(detail).toContainText(submitted.statementMd);
+    await expect(detail).toContainText(submitted.constraintsMd);
+
+    // Sections that were left blank on the form are not rendered
+    const sections = detail.locator('.problem-detail-section-title');
+    const sectionTitles = await sections.allTextContents();
+    expect(sectionTitles.some((t) => /input/i.test(t))).toBe(false);
+    expect(sectionTitles.some((t) => /output/i.test(t))).toBe(false);
+    expect(sectionTitles.some((t) => /hint/i.test(t))).toBe(false);
+  });
+
   test('difficulty filter isolates problems created with that difficulty', async ({ page }) => {
     await setupAuth(page);
     await mockBackend(page);

--- a/src/frontend/tests/create-problem.spec.js
+++ b/src/frontend/tests/create-problem.spec.js
@@ -1,0 +1,303 @@
+// @ts-check
+//
+// Acceptance test — Problem creation flow
+// ----------------------------------------
+// Main scenario: create a problem on create.html, then verify it appears on
+// problems.html. A single in-memory mock backend persists state across both
+// page navigations via closure (see mockBackend).
+//
+// Reuses the project's existing Playwright setup (playwright.config.js):
+//   - file:// baseURL serving the static frontend
+//   - Same auth bypass pattern as responsiveness.spec.js (fake token in localStorage)
+//   - Same route-mocking pattern as problems-page.spec.js
+//
+// These are functional tests, so they only run on the desktop project — the
+// mobile/tablet viewports are exercised by responsiveness.spec.js.
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const pages = {
+  create:   `file://${path.resolve(__dirname, '..', 'create.html')}`,
+  problems: `file://${path.resolve(__dirname, '..', 'problems.html')}`,
+};
+
+// create.js / problems.js redirect to login when no token is present.
+// auth.isAuthenticated() only checks that the key exists, not that it's valid.
+async function setupAuth(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('session_token', 'fake-test-token');
+  });
+}
+
+/**
+ * Stand-in backend that lives in test memory and survives page navigation.
+ * Handles:
+ *   POST /api/problems        → appends and returns 201 with the created record
+ *   GET  /api/problems        → returns the current state, filtered by query params
+ *   GET  /api/problems/<id>   → returns the full record (used by the detail panel)
+ */
+async function mockBackend(page, initialProblems = []) {
+  const state = { problems: [...initialProblems] };
+
+  await page.route('http://localhost:10000/api/problems**', async (route) => {
+    const request  = route.request();
+    const method   = request.method();
+    const url      = new URL(request.url());
+    const pathname = url.pathname;
+
+    // Detail endpoint: /api/problems/<id>
+    const detailMatch = pathname.match(/^\/api\/problems\/([^/]+)$/);
+    if (method === 'GET' && detailMatch) {
+      const id = detailMatch[1];
+      const problem = state.problems.find((p) => p.id === id);
+      if (!problem) {
+        await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(problem),
+      });
+      return;
+    }
+
+    if (method === 'POST') {
+      const body = JSON.parse(request.postData() || '{}');
+      const slug = body.slug || (body.title || '').toLowerCase().trim().replace(/\s+/g, '-');
+      // Preserve every field submitted — problems.js will read them back from the detail endpoint.
+      const created = {
+        ...body,
+        id:            `id-${state.problems.length + 1}`,
+        slug,
+        createdAt:     new Date().toISOString(),
+        languages:     ['Python 3'],
+        languageCodes: ['python'],
+      };
+      state.problems.push(created);
+
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(created),
+      });
+      return;
+    }
+
+    if (method === 'GET') {
+      const difficulty = (url.searchParams.get('difficulty') || '').toUpperCase();
+      const name       = (url.searchParams.get('name')       || '').toLowerCase();
+      const language   = (url.searchParams.get('language')   || '').toLowerCase();
+
+      const filtered = state.problems.filter((p) => {
+        const okDifficulty = !difficulty || p.difficulty === difficulty;
+        const okName       = !name       || (p.title || '').toLowerCase().includes(name);
+        const okLanguage   = !language   || (p.languageCodes || []).includes(language);
+        return okDifficulty && okName && okLanguage;
+      });
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(filtered),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
+/**
+ * Fills the required form fields and submits, awaiting the success banner.
+ * @param {import('@playwright/test').Page} page
+ * @param {{ title: string, statementMd: string, difficulty: 'EASY' | 'MEDIUM' | 'HARD', constraintsMd?: string }} fields
+ */
+async function createProblem(page, { title, statementMd, difficulty, constraintsMd }) {
+  await page.fill('#title', title);
+  await page.fill('#statementMd', statementMd);
+  if (constraintsMd) await page.fill('#constraintsMd', constraintsMd);
+  await page.selectOption('#difficulty', difficulty);
+  await page.click('#submit-btn');
+  await expect(page.locator('#status-message')).toHaveAttribute('data-status', 'success');
+}
+
+test.describe('Problem creation flow', () => {
+  // Functional test — run once, on desktop only.
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'Functional test runs on desktop only');
+  });
+
+  test('creates a new problem and shows it on the problems list', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [
+      {
+        slug:          'two-sum',
+        title:         'Two Sum',
+        difficulty:    'EASY',
+        createdAt:     '2026-01-01T10:00:00Z',
+        languages:     ['Python 3'],
+        languageCodes: ['python'],
+      },
+    ]);
+
+    // ── Step 1: fill the form on create.html ──────────────────────────────
+    await page.goto(pages.create);
+
+    await page.fill('#title',         'Reverse Linked List');
+    await page.fill('#statementMd',   'Given the head of a singly linked list, reverse the list and return its head.');
+    await page.fill('#constraintsMd', '0 <= n <= 5000');
+    await page.selectOption('#difficulty', 'MEDIUM');
+    await page.click('#submit-btn');
+
+    // Status banner reflects the success returned by the mock POST
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('Problem "Reverse Linked List" created successfully!');
+    await expect(status).toHaveAttribute('data-status', 'success');
+
+    // create.js calls form.reset() after success — fields should be empty again
+    await expect(page.locator('#title')).toHaveValue('');
+    await expect(page.locator('#statementMd')).toHaveValue('');
+
+    // ── Step 2: confirm it shows up on problems.html ──────────────────────
+    await page.goto(pages.problems);
+
+    await expect(page.locator('.problem-card')).toHaveCount(2);
+
+    const titles = page.locator('.problem-card-title');
+    await expect(titles).toContainText(['Two Sum', 'Reverse Linked List']);
+
+    // Filtering by name should isolate the new problem
+    await page.fill('#search-name', 'reverse');
+    await expect(page.locator('.problem-card')).toHaveCount(1);
+    await expect(page.locator('.problem-card-title')).toHaveText('Reverse Linked List');
+  });
+
+  test('blocks submission when required fields are missing', async ({ page }) => {
+    await setupAuth(page);
+
+    // Track whether create.js actually fires a POST despite the empty form
+    let postCount = 0;
+    await page.route('http://localhost:10000/api/problems**', async (route) => {
+      if (route.request().method() === 'POST') postCount += 1;
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    });
+
+    await page.goto(pages.create);
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('Title, statement and difficulty are required.');
+    await expect(status).toHaveAttribute('data-status', 'error');
+    expect(postCount).toBe(0);
+  });
+
+  test('shows a conflict message when the slug is already taken', async ({ page }) => {
+    await setupAuth(page);
+    await page.route('http://localhost:10000/api/problems**', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'A problem with that slug already exists.' }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    });
+
+    await page.goto(pages.create);
+    await page.fill('#title',       'Two Sum');
+    await page.fill('#statementMd', 'Duplicate of an existing problem.');
+    await page.selectOption('#difficulty', 'EASY');
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status-message');
+    await expect(status).toContainText('Conflict:');
+    await expect(status).toHaveAttribute('data-status', 'error');
+  });
+
+  test('shows the created problem details when its card is clicked', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page);
+
+    await page.goto(pages.create);
+    await createProblem(page, {
+      title:         'Binary Search',
+      statementMd:   'Given a sorted array and a target, return the target index or -1.',
+      constraintsMd: '1 <= n <= 10^5 and array is sorted ascending',
+      difficulty:    'EASY',
+    });
+
+    await page.goto(pages.problems);
+
+    const card = page.locator('.problem-card').first();
+    await expect(card).toBeVisible();
+    await card.click();
+
+    // Detail panel expands and renders the statement + constraints sections
+    await expect(card).toHaveClass(/is-expanded/);
+    const detail = card.locator('.problem-detail');
+    await expect(detail).toHaveClass(/is-open/);
+    await expect(detail).toContainText('Given a sorted array and a target');
+    await expect(detail).toContainText('1 <= n <= 10^5 and array is sorted ascending');
+    await expect(detail.locator('.problem-detail-start-btn')).toBeVisible();
+
+    // Clicking again collapses the detail panel
+    await card.click();
+    await expect(card).not.toHaveClass(/is-expanded/);
+    await expect(detail).not.toHaveClass(/is-open/);
+  });
+
+  test('renders the correct badge and card colour for each difficulty', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page);
+
+    await page.goto(pages.create);
+    await createProblem(page, { title: 'Easy One',   statementMd: 'Trivial problem.',     difficulty: 'EASY'   });
+    await createProblem(page, { title: 'Medium One', statementMd: 'Moderate problem.',    difficulty: 'MEDIUM' });
+    await createProblem(page, { title: 'Hard One',   statementMd: 'Difficult problem.',   difficulty: 'HARD'   });
+
+    await page.goto(pages.problems);
+    await expect(page.locator('.problem-card')).toHaveCount(3);
+
+    // Default sort is by difficulty (EASY → MEDIUM → HARD), then alphabetical
+    const cards   = page.locator('.problem-card');
+    const titles  = cards.locator('.problem-card-title');
+    const badges  = cards.locator('.badge');
+    await expect(titles).toHaveText(['Easy One', 'Medium One', 'Hard One']);
+
+    await expect(cards.nth(0)).toHaveClass(/card--green/);
+    await expect(cards.nth(1)).toHaveClass(/card--orange/);
+    await expect(cards.nth(2)).toHaveClass(/card--red/);
+
+    await expect(badges.nth(0)).toHaveClass(/badge--easy/);
+    await expect(badges.nth(1)).toHaveClass(/badge--medium/);
+    await expect(badges.nth(2)).toHaveClass(/badge--hard/);
+  });
+
+  test('difficulty filter isolates problems created with that difficulty', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page);
+
+    await page.goto(pages.create);
+    await createProblem(page, { title: 'Alpha', statementMd: 'A simple one.',  difficulty: 'EASY' });
+    await createProblem(page, { title: 'Beta',  statementMd: 'A tricky one.',  difficulty: 'HARD' });
+    await createProblem(page, { title: 'Gamma', statementMd: 'Another hard.',  difficulty: 'HARD' });
+
+    await page.goto(pages.problems);
+    await expect(page.locator('.problem-card')).toHaveCount(3);
+
+    await page.selectOption('#filter-difficulty', 'HARD');
+    await expect(page.locator('.problem-card')).toHaveCount(2);
+    await expect(page.locator('.problem-card-title')).toContainText(['Beta', 'Gamma']);
+
+    await page.selectOption('#filter-difficulty', 'EASY');
+    await expect(page.locator('.problem-card')).toHaveCount(1);
+    await expect(page.locator('.problem-card-title')).toHaveText('Alpha');
+
+    await page.click('#clear-filters');
+    await expect(page.locator('.problem-card')).toHaveCount(3);
+  });
+});

--- a/src/frontend/tests/edit-delete.spec.js
+++ b/src/frontend/tests/edit-delete.spec.js
@@ -1,0 +1,275 @@
+// @ts-check
+//
+// Acceptance test — Problem edit & delete (CRUD U + D)
+// -----------------------------------------------------
+// Edit flow: edit.html?id=<id> pre-fills the form from GET /api/problems/<id>
+// and submits a PUT /api/problems/<id> on save.
+// Delete flow: profile_page.html lists "My Problems" with Delete buttons that
+// confirm() then DELETE /api/problems/<id>.
+//
+// Reuses the existing Playwright setup (file:// baseURL, fake-token auth bypass,
+// route-mocking pattern from create-problem.spec.js / problems-page.spec.js).
+// Functional coverage only — desktop project, mobile/tablet are out of scope.
+
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const pages = {
+  edit:    `file://${path.resolve(__dirname, '..', 'edit.html')}`,
+  profile: `file://${path.resolve(__dirname, '..', 'profile_page.html')}`,
+};
+
+// auth.isAuthenticated() only checks that a token exists, and getValidToken()
+// returns the token unchanged unless it has the special expirable payload format
+// — a plain string like 'fake-test-token' skips the refresh path entirely.
+async function setupAuth(page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('session_token', 'fake-test-token');
+    localStorage.setItem('user_data', JSON.stringify({
+      id: 'u-1',
+      username: 'testuser',
+      email: 'test@example.com',
+    }));
+  });
+}
+
+/**
+ * Stand-in backend that lives in test memory and survives page navigation.
+ * Handles every endpoint edit.html / profile_page.html may call:
+ *   GET    /api/problems/<id>           detail used by edit.js loadProblem()
+ *   GET    /api/problems/by-author/<id> "My Problems" list on profile_page
+ *   GET    /api/problems                fallback list (profile difficulty stats)
+ *   GET    /api/submissions/mine        profile stats
+ *   GET    /api/users/...               profile user refresh
+ *   PUT    /api/problems/<id>           edit submission
+ *   DELETE /api/problems/<id>           profile delete
+ */
+async function mockBackend(page, initialProblems = [], userId = 'u-1') {
+  const state = { problems: [...initialProblems] };
+
+  await page.route('http://localhost:10000/api/**', async (route) => {
+    const request  = route.request();
+    const method   = request.method();
+    const url      = new URL(request.url());
+    const pathname = url.pathname;
+
+    // ── Problems by author (profile page "My Problems" table) ──────────────
+    const byAuthorMatch = pathname.match(/^\/api\/problems\/by-author\/([^/]+)$/);
+    if (method === 'GET' && byAuthorMatch) {
+      const author = byAuthorMatch[1];
+      const filtered = state.problems.filter((p) => (p.authorId || userId) === author);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(filtered),
+      });
+      return;
+    }
+
+    // ── Problem detail / update / delete ───────────────────────────────────
+    const detailMatch = pathname.match(/^\/api\/problems\/([^/]+)$/);
+    if (detailMatch) {
+      const id = detailMatch[1];
+      const idx = state.problems.findIndex((p) => p.id === id);
+
+      if (method === 'GET') {
+        if (idx === -1) {
+          await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(state.problems[idx]),
+        });
+        return;
+      }
+
+      if (method === 'PUT') {
+        if (idx === -1) {
+          await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+          return;
+        }
+        const body = JSON.parse(request.postData() || '{}');
+        state.problems[idx] = { ...state.problems[idx], ...body };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(state.problems[idx]),
+        });
+        return;
+      }
+
+      if (method === 'DELETE') {
+        if (idx === -1) {
+          await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+          return;
+        }
+        state.problems.splice(idx, 1);
+        await route.fulfill({ status: 204, body: '' });
+        return;
+      }
+    }
+
+    // ── Generic problems list (profile difficulty stats) ───────────────────
+    if (method === 'GET' && pathname === '/api/problems') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(state.problems),
+      });
+      return;
+    }
+
+    // ── Submissions list (profile stats) ───────────────────────────────────
+    if (method === 'GET' && pathname.startsWith('/api/submissions')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+      });
+      return;
+    }
+
+    // ── User lookups (profile may refresh user data) ───────────────────────
+    if (method === 'GET' && pathname.startsWith('/api/users')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: userId, username: 'testuser', email: 'test@example.com' }),
+      });
+      return;
+    }
+
+    // Anything we forgot to mock should fail loudly rather than hit the network.
+    await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+  });
+
+  return state;
+}
+
+const SAMPLE_PROBLEM = {
+  id:               'id-1',
+  authorId:         'u-1',
+  slug:             'two-sum',
+  title:            'Two Sum',
+  statementMd:      'Given an array of integers, return indices of the two numbers that add up to a target.',
+  difficulty:       'EASY',
+  constraintsMd:    '2 <= nums.length <= 10^4',
+  solutionTemplate: 'def two_sum(nums, target):\n    pass',
+  createdAt:        '2026-01-01T10:00:00Z',
+  languages:        ['Python 3'],
+  languageCodes:    ['python'],
+};
+
+test.describe('Problem edit flow', () => {
+  // Functional test — run once, on desktop only.
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'Functional test runs on desktop only');
+  });
+
+  test('pre-fills the form with the problem\'s existing data', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+
+    // loadProblem() is async — wait for setField() to run before asserting.
+    await expect(page.locator('#title')).toHaveValue(SAMPLE_PROBLEM.title);
+    await expect(page.locator('#statementMd')).toHaveValue(SAMPLE_PROBLEM.statementMd);
+    await expect(page.locator('#difficulty')).toHaveValue(SAMPLE_PROBLEM.difficulty);
+    await expect(page.locator('#constraintsMd')).toHaveValue(SAMPLE_PROBLEM.constraintsMd);
+    await expect(page.locator('#solutionTemplate')).toHaveValue(SAMPLE_PROBLEM.solutionTemplate);
+  });
+
+  test('saves changes and shows the success banner', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+    await expect(page.locator('#title')).toHaveValue(SAMPLE_PROBLEM.title);
+
+    await page.fill('#title', 'Two Sum (Revised)');
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('Problem updated successfully!');
+    await expect(status).toHaveAttribute('data-status', 'success');
+  });
+
+  test('sends the exact edited values to the API', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    /** @type {any} */
+    let capturedBody = null;
+    // Layer a targeted spy on top of the mockBackend route — Playwright runs
+    // handlers most-recent first, so this captures PUTs while everything else
+    // (including the initial GET) still falls through to the closure backend.
+    await page.route(`http://localhost:10000/api/problems/${SAMPLE_PROBLEM.id}`, async (route) => {
+      if (route.request().method() === 'PUT') {
+        capturedBody = JSON.parse(route.request().postData() || '{}');
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ...SAMPLE_PROBLEM, ...capturedBody }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+    await expect(page.locator('#title')).toHaveValue(SAMPLE_PROBLEM.title);
+
+    await page.fill('#title',            'Reverse Linked List');
+    await page.fill('#statementMd',      'Reverse a singly linked list and return the new head.');
+    await page.fill('#constraintsMd',    '0 <= n <= 5000');
+    await page.fill('#solutionTemplate', 'def reverse(head):\n    return head');
+    await page.selectOption('#difficulty', 'MEDIUM');
+
+    await page.click('#submit-btn');
+    await expect(page.locator('#status-message')).toHaveAttribute('data-status', 'success');
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody.title).toBe('Reverse Linked List');
+    expect(capturedBody.statementMd).toBe('Reverse a singly linked list and return the new head.');
+    expect(capturedBody.constraintsMd).toBe('0 <= n <= 5000');
+    expect(capturedBody.solutionTemplate).toBe('def reverse(head):\n    return head');
+    expect(capturedBody.difficulty).toBe('MEDIUM');
+  });
+
+  test('blocks submission when required fields are missing', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    // Spy on PUTs so we can assert nothing was sent.
+    let putCount = 0;
+    await page.route(`http://localhost:10000/api/problems/${SAMPLE_PROBLEM.id}`, async (route) => {
+      if (route.request().method() === 'PUT') putCount += 1;
+      await route.fallback();
+    });
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+    await expect(page.locator('#title')).toHaveValue(SAMPLE_PROBLEM.title);
+
+    await page.fill('#title', '');
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('Title, statement and difficulty are required.');
+    await expect(status).toHaveAttribute('data-status', 'error');
+    expect(putCount).toBe(0);
+  });
+
+  test('redirects to the profile page when the id query parameter is missing', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page);
+
+    await page.goto(pages.edit);
+
+    // edit.js redirects via window.location.href = 'profile_page.html'.
+    await page.waitForURL(/profile_page\.html$/);
+    expect(page.url()).toMatch(/profile_page\.html$/);
+  });
+});

--- a/src/frontend/tests/edit-delete.spec.js
+++ b/src/frontend/tests/edit-delete.spec.js
@@ -272,4 +272,204 @@ test.describe('Problem edit flow', () => {
     await page.waitForURL(/profile_page\.html$/);
     expect(page.url()).toMatch(/profile_page\.html$/);
   });
+
+  test('shows a load error when the problem cannot be fetched', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    // Override the detail GET to fail. Most-recent route runs first, so this
+    // intercepts before the mockBackend closure ever sees the request.
+    await page.route(`http://localhost:10000/api/problems/${SAMPLE_PROBLEM.id}`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Internal server error' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('Could not load the problem. Please go back and try again.');
+    await expect(status).toHaveAttribute('data-status', 'error');
+
+    // Form stayed empty — nothing was pre-filled.
+    await expect(page.locator('#title')).toHaveValue('');
+    await expect(page.locator('#statementMd')).toHaveValue('');
+  });
+
+  test('shows a forbidden error when the user is not allowed to edit the problem', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    // GET still serves the form; only the PUT is blocked.
+    await page.route(`http://localhost:10000/api/problems/${SAMPLE_PROBLEM.id}`, async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Forbidden' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+    await expect(page.locator('#title')).toHaveValue(SAMPLE_PROBLEM.title);
+
+    await page.fill('#title', 'Two Sum (Revised)');
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('You are not allowed to edit this problem.');
+    await expect(status).toHaveAttribute('data-status', 'error');
+
+    // The submit button must recover after the failed request — the finally
+    // block in submitEditProblem() re-enables it and restores the label.
+    const submit = page.locator('#submit-btn');
+    await expect(submit).toBeEnabled();
+    await expect(submit).toHaveText('Save Changes');
+  });
+
+  test('shows a network error when the server cannot be reached', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, [SAMPLE_PROBLEM]);
+
+    // GET pre-fills the form; PUT is aborted to simulate a dropped connection.
+    await page.route(`http://localhost:10000/api/problems/${SAMPLE_PROBLEM.id}`, async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.abort('failed');
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(`${pages.edit}?id=${SAMPLE_PROBLEM.id}`);
+    await expect(page.locator('#title')).toHaveValue(SAMPLE_PROBLEM.title);
+
+    await page.fill('#title', 'Two Sum (Revised)');
+    await page.click('#submit-btn');
+
+    const status = page.locator('#status-message');
+    await expect(status).toHaveText('Could not reach the server. Is the backend running?');
+    await expect(status).toHaveAttribute('data-status', 'error');
+  });
+});
+
+const TWO_PROBLEMS = [
+  { ...SAMPLE_PROBLEM, id: 'id-1', title: 'Two Sum',            difficulty: 'EASY'   },
+  { ...SAMPLE_PROBLEM, id: 'id-2', title: 'Reverse Linked List', difficulty: 'MEDIUM' },
+];
+
+test.describe('Problem delete flow', () => {
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'Functional test runs on desktop only');
+  });
+
+  test('removes the row and decrements the count when the user confirms', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, TWO_PROBLEMS);
+
+    // Accept every dialog (one confirm() in this scenario).
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await page.goto(pages.profile);
+
+    // Wait for the My Problems table and the created-count to render.
+    await expect(page.locator('[data-delete]')).toHaveCount(2);
+    await expect(page.locator('#profile-created-count')).toHaveText('2');
+
+    // Capture the DELETE so we can wait for it deterministically.
+    const deleteResponse = page.waitForResponse(
+      (resp) =>
+        resp.url() === 'http://localhost:10000/api/problems/id-1' &&
+        resp.request().method() === 'DELETE',
+    );
+
+    await page.click('[data-delete="id-1"]');
+    const response = await deleteResponse;
+    expect(response.status()).toBe(204);
+
+    // The deleted row is gone, the surviving row stays, the count is decremented.
+    await expect(page.locator('[data-delete]')).toHaveCount(1);
+    await expect(page.locator('[data-delete="id-1"]')).toHaveCount(0);
+    await expect(page.locator('[data-delete="id-2"]')).toHaveCount(1);
+    await expect(page.locator('#profile-created-count')).toHaveText('1');
+  });
+
+  test('does not delete when the user cancels the confirmation dialog', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, TWO_PROBLEMS);
+
+    // Dismiss the confirm() → returns false → deleteProblem() bails out early.
+    page.on('dialog', (dialog) => dialog.dismiss());
+
+    // Spy on DELETEs to prove none fire.
+    let deleteCount = 0;
+    await page.route('http://localhost:10000/api/problems/**', async (route) => {
+      if (route.request().method() === 'DELETE') deleteCount += 1;
+      await route.fallback();
+    });
+
+    await page.goto(pages.profile);
+    await expect(page.locator('[data-delete]')).toHaveCount(2);
+    await expect(page.locator('#profile-created-count')).toHaveText('2');
+
+    await page.click('[data-delete="id-1"]');
+
+    // Give the click a moment to flush — if a DELETE were going to fire, it would
+    // have done so synchronously after confirm() returned. State stays untouched.
+    await page.waitForTimeout(100);
+    expect(deleteCount).toBe(0);
+    await expect(page.locator('[data-delete]')).toHaveCount(2);
+    await expect(page.locator('#profile-created-count')).toHaveText('2');
+  });
+
+  test('shows an alert and keeps the row when the delete request fails', async ({ page }) => {
+    await setupAuth(page);
+    await mockBackend(page, TWO_PROBLEMS);
+
+    // The confirm() fires first, then on 403 the catch block fires alert().
+    // Accept both, capturing their messages so we can assert on the alert.
+    /** @type {{type: string, message: string}[]} */
+    const dialogs = [];
+    page.on('dialog', async (dialog) => {
+      dialogs.push({ type: dialog.type(), message: dialog.message() });
+      await dialog.accept();
+    });
+
+    // Override DELETE for id-1 only — leave id-2 alone.
+    await page.route('http://localhost:10000/api/problems/id-1', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        await route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Forbidden' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto(pages.profile);
+    await expect(page.locator('[data-delete]')).toHaveCount(2);
+
+    await page.click('[data-delete="id-1"]');
+
+    // Wait until both dialogs (confirm + alert) have been observed.
+    await expect.poll(() => dialogs.length).toBe(2);
+    expect(dialogs[0].type).toBe('confirm');
+    expect(dialogs[1].type).toBe('alert');
+    expect(dialogs[1].message).toBe('Could not delete the problem. You may not have permission.');
+
+    // Row was not removed and the count was not changed.
+    await expect(page.locator('[data-delete]')).toHaveCount(2);
+    await expect(page.locator('[data-delete="id-1"]')).toHaveCount(1);
+    await expect(page.locator('#profile-created-count')).toHaveText('2');
+  });
 });


### PR DESCRIPTION
## Acceptance tests — Problem CRUD

Two Playwright suites covering the full create / edit / delete lifecycle on the frontend. **19 tests, desktop project only, all-mock backend** — no live server, no new config.

### Files

- [src/frontend/tests/create-problem.spec.js](src/frontend/tests/create-problem.spec.js) — **8 tests**: happy-path create + list, client validation, 409 conflict, detail panel, difficulty styling, POST body fidelity, form↔API↔card round-trip, difficulty filter.
- [src/frontend/tests/edit-delete.spec.js](src/frontend/tests/edit-delete.spec.js) — **11 tests**:
  - *Edit (8):* form pre-fill, successful PUT, body fidelity, missing-field validation, redirect when `?id` absent, GET 500, PUT 403, PUT network abort.
  - *Delete (3):* confirmed delete removes row + decrements counter, cancelled confirm fires no request, DELETE 403 surfaces an alert and preserves state.

### How it works

- Auth bypass via `localStorage` seed (`session_token` + `user_data`).
- One `page.route('/api/**')` closure per test owns an in-memory state; failure modes layer a more-specific route on top and use `route.fallback()` for everything else.
- `page.on('dialog')` covers `confirm()` and `alert()` in the delete tests.

### Run

```bash
cd src/frontend
npm test                                       # full suite — 79 pass, 62 skipped
npm run test:desktop -- edit-delete.spec.js    # this PR only
```
