### PR TITLE
add problem solver page and example editing from profile

### DIFF
--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/controller/ProblemController.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/controller/ProblemController.java
@@ -8,6 +8,7 @@ import com.bspq26e8.backend.problem.service.ProblemService.CreateProblemResult;
 import com.bspq26e8.backend.problem.service.ProblemService.ExampleInput;
 import com.bspq26e8.backend.problem.service.ProblemService.ProblemDetail;
 import com.bspq26e8.backend.problem.service.ProblemService.ProblemSummary;
+import com.bspq26e8.backend.problem.service.ProblemService.UpdateExamplesResult;
 import com.bspq26e8.backend.problem.service.ProblemService.UpdateProblemCommand;
 import com.bspq26e8.backend.problem.service.ProblemService.UpdateProblemResult;
 import java.util.List;
@@ -207,6 +208,30 @@ public class ProblemController {
 		}
 
 		return ResponseEntity.ok(result.problem());
+	}
+
+	@PutMapping("/{problemId}/examples")
+	public ResponseEntity<?> updateProblemExamples(
+			@PathVariable UUID problemId,
+			@RequestBody(required = false) List<ExampleInput> examples,
+			HttpServletRequest httpRequest
+	) {
+		Optional<UUID> authenticatedUserId = authenticatedUserId(httpRequest);
+		if (authenticatedUserId.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error("Missing or invalid access token"));
+		}
+
+		List<ExampleInput> normalized = examples == null ? List.of() :
+				examples.stream()
+						.filter(ex -> ex != null && ex.inputData() != null && !ex.inputData().isBlank())
+						.map(ex -> new ExampleInput(ex.inputData().trim(),
+								ex.expectedOutput() == null ? "" : ex.expectedOutput().trim()))
+						.toList();
+
+		UpdateExamplesResult result = problemService.updateExamplesByAuthor(problemId, authenticatedUserId.get(), normalized);
+		if (result.notFound())  return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error(result.errorMessage()));
+		if (result.forbidden()) return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error(result.errorMessage()));
+		return ResponseEntity.ok().build();
 	}
 
 	private String slugify(String input) {

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/TestCase.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/entity/TestCase.java
@@ -44,6 +44,8 @@ public class TestCase {
         return isSample;
     }
 
+    protected TestCase() {}
+
     public TestCase(Problem problem, String inputData, String expectedOutput, boolean isSample) {
         this.problem = problem;
         this.inputData = inputData;

--- a/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
+++ b/src/backend/src/main/java/com/bspq26e8/backend/problem/service/ProblemService.java
@@ -7,6 +7,7 @@ import com.bspq26e8.backend.problem.repository.ProblemLanguageRepository;
 import com.bspq26e8.backend.problem.repository.ProblemRepository;
 import com.bspq26e8.backend.user.entity.User;
 import com.bspq26e8.backend.user.repository.UserRepository;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -168,6 +169,41 @@ public class ProblemService {
 				problem.getHintsMd(),
 				examples
 		));
+	}
+
+	@Transactional
+	public UpdateExamplesResult updateExamplesByAuthor(UUID problemId, UUID authorId, List<ExampleInput> examples) {
+		Optional<Problem> maybeProblem = problemRepository.findById(problemId);
+		if (maybeProblem.isEmpty()) {
+			return UpdateExamplesResult.notFound("Problem not found");
+		}
+
+		Problem problem = maybeProblem.get();
+		if (problem.getAuthor() == null || !problem.getAuthor().getId().equals(authorId)) {
+			return UpdateExamplesResult.forbidden("Only the author can edit this problem");
+		}
+
+		// Modify the Hibernate-managed collection in-place to avoid
+		// "collection no longer referenced" error with cascade=all-delete-orphan
+		if (problem.getTestCases() == null) {
+			problem.setTestCases(new ArrayList<>());
+		}
+
+		// Remove existing sample test cases in-place
+		problem.getTestCases().removeIf(TestCase::isSample);
+
+		// Add new sample test cases into the existing managed collection
+		if (examples != null) {
+			examples.stream()
+					.filter(ex -> ex.inputData() != null && !ex.inputData().isBlank())
+					.map(ex -> new TestCase(problem, ex.inputData().trim(),
+							ex.expectedOutput() == null ? "" : ex.expectedOutput().trim(), true))
+					.forEach(tc -> problem.getTestCases().add(tc));
+		}
+
+		problemRepository.save(problem);
+
+		return UpdateExamplesResult.success();
 	}
 
 	public Optional<DeleteProblemError> deleteProblemByAuthor(UUID problemId, UUID authorId) {
@@ -343,6 +379,18 @@ public class ProblemService {
 
 		public static UpdateProblemResult conflict(String message) {
 			return new UpdateProblemResult(false, false, false, message, null);
+		}
+	}
+
+	public record UpdateExamplesResult(boolean updated, boolean notFound, boolean forbidden, String errorMessage) {
+		public static UpdateExamplesResult success() {
+			return new UpdateExamplesResult(true, false, false, null);
+		}
+		public static UpdateExamplesResult notFound(String message) {
+			return new UpdateExamplesResult(false, true, false, message);
+		}
+		public static UpdateExamplesResult forbidden(String message) {
+			return new UpdateExamplesResult(false, false, true, message);
 		}
 	}
 

--- a/src/frontend/css/solve.css
+++ b/src/frontend/css/solve.css
@@ -1,0 +1,365 @@
+/* ══════════════════════════════════════════════
+   solve.css — Split-screen problem solver page
+   ══════════════════════════════════════════════ */
+
+/* ── Layout ── */
+.solve-layout {
+  display: flex;
+  height: calc(100vh - 52px);
+  margin-top: 52px;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ── Panels ── */
+.solve-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 280px;
+}
+
+.solve-panel--desc {
+  width: 42%;
+  border-right: 1px solid var(--border);
+  background: var(--card);
+}
+
+.solve-panel--editor {
+  flex: 1;
+  background: var(--bg);
+}
+
+/* ── Draggable divider ── */
+.solve-divider {
+  width: 4px;
+  background: var(--border);
+  cursor: col-resize;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+.solve-divider:hover,
+.solve-divider.is-dragging {
+  background: var(--accent);
+}
+
+/* ══ LEFT PANEL ══════════════════════════════ */
+
+/* Tabs */
+.solve-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--sidebar);
+  flex-shrink: 0;
+}
+
+.solve-tab {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.75rem 1.25rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-mid);
+  cursor: pointer;
+  transition: color var(--transition), border-color var(--transition);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.solve-tab:hover { color: var(--text); }
+.solve-tab.is-active {
+  color: var(--accent-light);
+  border-bottom-color: var(--accent);
+}
+
+/* Tab content area */
+.solve-tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem 1.5rem 2rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.solve-tab-content::-webkit-scrollbar { width: 5px; }
+.solve-tab-content::-webkit-scrollbar-track { background: transparent; }
+.solve-tab-content::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+/* Problem header */
+.solve-problem-header {
+  margin-bottom: 1.5rem;
+}
+
+.solve-problem-title {
+  font-family: var(--font-body);
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--white);
+  margin-bottom: 0.6rem;
+  line-height: 1.3;
+}
+
+.solve-problem-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Sections */
+.solve-section {
+  margin-bottom: 1.5rem;
+}
+
+.solve-section-title {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--accent-light);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.solve-section-title::before {
+  content: '//';
+  color: var(--accent);
+}
+
+.solve-section-body {
+  font-size: 0.9rem;
+  color: var(--text-mid);
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+/* Examples */
+.solve-examples {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.solve-example {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.solve-example-label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--sidebar);
+}
+
+.solve-example-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+
+.solve-example-block {
+  padding: 0.6rem 0.75rem;
+}
+
+.solve-example-block + .solve-example-block {
+  border-left: 1px solid var(--border);
+}
+
+.solve-example-block-label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.3rem;
+}
+
+.solve-example-code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  background: none;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Loading / error */
+.solve-loading,
+.solve-error {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 2rem 0;
+  text-align: center;
+}
+.solve-loading { color: var(--text-dim); }
+.solve-error   { color: var(--red); }
+
+/* Hints tab */
+.solve-hints-empty {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  text-align: center;
+  padding: 2rem 0;
+}
+
+/* ══ RIGHT PANEL ═════════════════════════════ */
+
+/* Toolbar */
+.solve-editor-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  background: var(--sidebar);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 0.75rem;
+}
+
+.solve-lang-select {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  outline: none;
+  transition: border-color var(--transition);
+}
+.solve-lang-select:focus { border-color: var(--accent); }
+
+.solve-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Code editor area */
+.solve-editor-wrap {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.solve-editor {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  line-height: 1.6;
+  padding: 1.25rem 1.5rem;
+  border: none;
+  outline: none;
+  resize: none;
+  caret-color: var(--accent);
+  tab-size: 4;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.solve-editor::-webkit-scrollbar { width: 5px; }
+.solve-editor::-webkit-scrollbar-track { background: transparent; }
+.solve-editor::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+.solve-editor::selection { background: rgba(108, 99, 255, 0.3); }
+
+/* Output panel */
+.solve-output {
+  flex-shrink: 0;
+  max-height: 40%;
+  border-top: 1px solid var(--border);
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.solve-output-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--sidebar);
+  flex-shrink: 0;
+}
+
+.solve-output-title {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-mid);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.solve-output-status {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+}
+.solve-output-status.accepted  { color: var(--green);  background: rgba(34,197,94,.12); }
+.solve-output-status.error     { color: var(--red);    background: rgba(239,68,68,.12); }
+.solve-output-status.running   { color: var(--orange); background: rgba(245,158,11,.12); }
+
+.solve-output-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  transition: color var(--transition);
+}
+.solve-output-close:hover { color: var(--text); }
+
+.solve-output-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .solve-layout {
+    flex-direction: column;
+    height: auto;
+    overflow: auto;
+  }
+  .solve-panel--desc {
+    width: 100%;
+    height: 50vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+  .solve-divider { display: none; }
+  .solve-panel--editor {
+    height: 50vh;
+  }
+}

--- a/src/frontend/edit.html
+++ b/src/frontend/edit.html
@@ -52,8 +52,7 @@
 
         <div class="card">
           <div class="section-header">
-            <h3 class="section-title">Examples</h3>
-            <button type="button" class="btn-secondary btn-sm" id="examples-add-btn">+ Add</button>
+            <h3 class="section-title">Example</h3>
           </div>
           <div id="examples-container">
             <div class="example-box" data-example>
@@ -86,6 +85,7 @@
   </main>
 
   <!-- Core utilities -->
+  <script src="js/i18n.js"></script>
   <script src="js/layout.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/api.js"></script>

--- a/src/frontend/js/edit.js
+++ b/src/frontend/js/edit.js
@@ -48,10 +48,7 @@
   }
 
   function initExamples() {
-    const container = document.getElementById('examples-container');
-    const addBtn = document.getElementById('examples-add-btn');
-    if (!container || !addBtn) return;
-    addBtn.addEventListener('click', () => container.appendChild(buildExampleBlock()));
+    // single example only — no add button
   }
 
   /* ── Load problem data and pre-fill form ── */
@@ -87,6 +84,17 @@
       const statusEl = document.getElementById('status-message');
       if (statusEl) showStatus(statusEl, 'Could not load the problem. Please go back and try again.', 'error');
     }
+  }
+
+  /* ── Collect examples from the form ── */
+  function collectExamples() {
+    const container = document.getElementById('examples-container');
+    if (!container) return [];
+    const block = container.querySelector('[data-example]');
+    if (!block) return [];
+    const inputData      = (block.querySelector('[data-example-input]')?.value  || '').trim();
+    const expectedOutput = (block.querySelector('[data-example-output]')?.value || '').trim();
+    return inputData.length > 0 ? [{ inputData, expectedOutput }] : [];
   }
 
   /* ── Submit edit ── */
@@ -126,6 +134,7 @@
 
     try {
       await api.put(`/problems/${problemId}`, body);
+      await api.put(`/problems/${problemId}/examples`, collectExamples());
       showStatus(statusEl, 'Problem updated successfully!', 'success');
     } catch (err) {
       if (err && err.status === 401) {

--- a/src/frontend/js/problems.js
+++ b/src/frontend/js/problems.js
@@ -182,6 +182,7 @@
 
     detailEl.querySelector('.problem-detail-start-btn').addEventListener('click', (e) => {
       e.stopPropagation();
+      window.location.href = `solve.html?id=${data.id}`;
     });
   }
 

--- a/src/frontend/js/solve.js
+++ b/src/frontend/js/solve.js
@@ -1,0 +1,300 @@
+(function () {
+  'use strict';
+
+  /* ── URL param ── */
+  const params = new URLSearchParams(window.location.search);
+  const problemId = params.get('id');
+
+  /* ── Default code templates per language ── */
+  const TEMPLATES = {
+    python:
+      'class Solution:\n    def solve(self, ):\n        pass\n',
+    java:
+      'class Solution {\n    public void solve() {\n        \n    }\n}\n',
+    cpp:
+      'class Solution {\npublic:\n    void solve() {\n        \n    }\n};\n',
+    javascript:
+      '/**\n * @return {void}\n */\nvar solve = function() {\n    \n};\n',
+  };
+
+  /* ── State ── */
+  let problemData = null;
+
+  /* ── Element references ── */
+  const tabButtons    = document.querySelectorAll('.solve-tab');
+  const tabDesc       = document.getElementById('tab-description');
+  const tabExamples   = document.getElementById('tab-examples');
+  const tabHints      = document.getElementById('tab-hints');
+  const problemHeader = document.getElementById('problem-header');
+  const problemStmt   = document.getElementById('problem-statement');
+  const problemEx     = document.getElementById('problem-examples');
+  const problemHints  = document.getElementById('problem-hints');
+  const langSelect    = document.getElementById('lang-select');
+  const codeEditor    = document.getElementById('code-editor');
+  const btnRun        = document.getElementById('btn-run');
+  const btnSubmit     = document.getElementById('btn-submit');
+  const outputPanel   = document.getElementById('solve-output');
+  const outputStatus  = document.getElementById('output-status');
+  const outputBody    = document.getElementById('output-body');
+  const btnClose      = document.getElementById('btn-close-output');
+  const divider       = document.getElementById('solve-divider');
+  const leftPanel     = document.querySelector('.solve-panel--desc');
+
+  /* ── Tabs ── */
+  const TABS = {
+    description: tabDesc,
+    examples:    tabExamples,
+    hints:       tabHints,
+  };
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      tabButtons.forEach((b) => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      Object.values(TABS).forEach((el) => (el.style.display = 'none'));
+      const target = TABS[btn.dataset.tab];
+      if (target) target.style.display = 'block';
+    });
+  });
+
+  /* ── Escape HTML ── */
+  function esc(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /* ── Render left panel ── */
+  function renderProblem(data) {
+    problemData = data;
+
+    /* Header: title + difficulty */
+    const diffMap = {
+      EASY:   'badge--easy',
+      MEDIUM: 'badge--medium',
+      HARD:   'badge--hard',
+    };
+    const badgeClass = diffMap[data.difficulty] || 'badge--blue';
+
+    problemHeader.innerHTML = `
+      <div class="solve-problem-header">
+        <h1 class="solve-problem-title">${esc(data.title)}</h1>
+        <div class="solve-problem-meta">
+          <span class="badge ${badgeClass}">${esc(data.difficulty)}</span>
+        </div>
+      </div>`;
+
+    /* Statement */
+    const sections = [];
+    if (data.statementMd) {
+      sections.push(`
+        <div class="solve-section">
+          <span class="solve-section-title">Description</span>
+          <p class="solve-section-body">${esc(data.statementMd)}</p>
+        </div>`);
+    }
+    if (data.inputSpecMd) {
+      sections.push(`
+        <div class="solve-section">
+          <span class="solve-section-title">Input</span>
+          <p class="solve-section-body">${esc(data.inputSpecMd)}</p>
+        </div>`);
+    }
+    if (data.outputSpecMd) {
+      sections.push(`
+        <div class="solve-section">
+          <span class="solve-section-title">Output</span>
+          <p class="solve-section-body">${esc(data.outputSpecMd)}</p>
+        </div>`);
+    }
+    if (data.constraintsMd) {
+      sections.push(`
+        <div class="solve-section">
+          <span class="solve-section-title">Constraints</span>
+          <p class="solve-section-body">${esc(data.constraintsMd)}</p>
+        </div>`);
+    }
+    problemStmt.innerHTML = sections.join('');
+
+    /* Examples tab */
+    if (Array.isArray(data.examples) && data.examples.length > 0) {
+      const items = data.examples.map((ex, i) => `
+        <div class="solve-example">
+          <div class="solve-example-label">Example ${i + 1}</div>
+          <div class="solve-example-row">
+            <div class="solve-example-block">
+              <div class="solve-example-block-label">Input</div>
+              <pre class="solve-example-code">${esc(ex.inputData)}</pre>
+            </div>
+            <div class="solve-example-block">
+              <div class="solve-example-block-label">Output</div>
+              <pre class="solve-example-code">${esc(ex.expectedOutput)}</pre>
+            </div>
+          </div>
+        </div>`).join('');
+      problemEx.innerHTML = `<div class="solve-examples">${items}</div>`;
+    } else {
+      problemEx.innerHTML = '<p class="solve-hints-empty">No examples available.</p>';
+    }
+
+    /* Hints tab */
+    if (data.hintsMd) {
+      problemHints.innerHTML = `
+        <div class="solve-section">
+          <span class="solve-section-title">Hints</span>
+          <p class="solve-section-body">${esc(data.hintsMd)}</p>
+        </div>`;
+    }
+
+    /* Pre-fill editor with solutionTemplate or default */
+    setEditorTemplate();
+
+    /* Page title */
+    document.title = `${data.title} — Realcode`;
+  }
+
+  /* ── Editor template ── */
+  function setEditorTemplate() {
+    if (!problemData) return;
+    const lang = langSelect.value;
+    // Use the problem's solutionTemplate if available, otherwise use default
+    const template = problemData.solutionTemplate || TEMPLATES[lang] || '';
+    codeEditor.value = template;
+  }
+
+  langSelect.addEventListener('change', setEditorTemplate);
+
+  /* ── Tab key in editor (insert spaces) ── */
+  codeEditor.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const start = codeEditor.selectionStart;
+      const end = codeEditor.selectionEnd;
+      codeEditor.value =
+        codeEditor.value.substring(0, start) + '    ' + codeEditor.value.substring(end);
+      codeEditor.selectionStart = codeEditor.selectionEnd = start + 4;
+    }
+  });
+
+  /* ── Output panel helpers ── */
+  function showOutput(text, statusText, statusClass) {
+    outputBody.textContent = text;
+    outputStatus.textContent = statusText;
+    outputStatus.className = `solve-output-status ${statusClass}`;
+    outputPanel.style.display = 'flex';
+  }
+
+  function hideOutput() {
+    outputPanel.style.display = 'none';
+  }
+
+  btnClose.addEventListener('click', hideOutput);
+
+  /* ── Run ── */
+  btnRun.addEventListener('click', async () => {
+    if (!problemId) return;
+    const code = codeEditor.value;
+    const language = langSelect.value;
+
+    showOutput('Running…', 'Running', 'running');
+    btnRun.disabled = true;
+
+    try {
+      const result = await api.runCode(problemId, code, language);
+      const output = result.output || result.stdout || JSON.stringify(result, null, 2);
+      const isError = result.status === 'ERROR' || result.stderr;
+      showOutput(
+        isError ? (result.stderr || output) : output,
+        isError ? 'Error' : 'Finished',
+        isError ? 'error' : 'accepted'
+      );
+    } catch (err) {
+      showOutput(
+        err && err.message ? err.message : 'Could not reach the server.',
+        'Error',
+        'error'
+      );
+    } finally {
+      btnRun.disabled = false;
+    }
+  });
+
+  /* ── Submit ── */
+  btnSubmit.addEventListener('click', async () => {
+    if (!problemId) return;
+    const code = codeEditor.value;
+    const language = langSelect.value;
+
+    showOutput('Submitting…', 'Running', 'running');
+    btnSubmit.disabled = true;
+
+    try {
+      const result = await api.submitSolution(problemId, code, language);
+      const accepted = result.status === 'ACCEPTED' || result.accepted === true;
+      const output = result.output || result.message || JSON.stringify(result, null, 2);
+      showOutput(output, accepted ? 'Accepted' : 'Wrong Answer', accepted ? 'accepted' : 'error');
+    } catch (err) {
+      showOutput(
+        err && err.message ? err.message : 'Could not reach the server.',
+        'Error',
+        'error'
+      );
+    } finally {
+      btnSubmit.disabled = false;
+    }
+  });
+
+  /* ── Draggable divider ── */
+  if (divider && leftPanel) {
+    let dragging = false;
+    let startX = 0;
+    let startWidth = 0;
+
+    divider.addEventListener('mousedown', (e) => {
+      dragging = true;
+      startX = e.clientX;
+      startWidth = leftPanel.getBoundingClientRect().width;
+      divider.classList.add('is-dragging');
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      const delta = e.clientX - startX;
+      const newWidth = Math.min(Math.max(startWidth + delta, 280), window.innerWidth - 400);
+      leftPanel.style.width = `${newWidth}px`;
+    });
+
+    document.addEventListener('mouseup', () => {
+      if (!dragging) return;
+      dragging = false;
+      divider.classList.remove('is-dragging');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    });
+  }
+
+  /* ── Load problem ── */
+  async function loadProblem() {
+    if (!problemId) {
+      problemHeader.innerHTML = '<p class="solve-error">No problem selected. <a href="problems.html">Go back</a></p>';
+      return;
+    }
+
+    try {
+      const data = await api.get(`/problems/${problemId}`);
+      renderProblem(data);
+    } catch (_err) {
+      problemHeader.innerHTML = '<p class="solve-error">Could not load problem. Please go back and try again.</p>';
+    }
+  }
+
+  /* ── Init ── */
+  document.addEventListener('DOMContentLoaded', () => {
+    loadProblem();
+  });
+
+})();

--- a/src/frontend/solve.html
+++ b/src/frontend/solve.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Solve — Realcode</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Syne:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/base.css" />
+  <link rel="stylesheet" href="css/solve.css" />
+</head>
+<body data-active-nav="problems">
+
+  <!-- Navbar injected by layout.js -->
+
+  <div class="solve-layout">
+
+    <!-- ── LEFT: Problem description ── -->
+    <aside class="solve-panel solve-panel--desc">
+
+      <!-- Tabs -->
+      <div class="solve-tabs">
+        <button class="solve-tab is-active" data-tab="description">Description</button>
+        <button class="solve-tab" data-tab="examples">Examples</button>
+        <button class="solve-tab" data-tab="hints">Hints</button>
+      </div>
+
+      <!-- Description tab -->
+      <div class="solve-tab-content" id="tab-description">
+        <div id="problem-header">
+          <p class="solve-loading">Loading problem…</p>
+        </div>
+        <div id="problem-statement"></div>
+      </div>
+
+      <!-- Examples tab -->
+      <div class="solve-tab-content" id="tab-examples" style="display:none;">
+        <div id="problem-examples">
+          <p class="solve-loading">Loading…</p>
+        </div>
+      </div>
+
+      <!-- Hints tab -->
+      <div class="solve-tab-content" id="tab-hints" style="display:none;">
+        <div id="problem-hints">
+          <p class="solve-hints-empty">No hints available for this problem.</p>
+        </div>
+      </div>
+
+    </aside>
+
+    <!-- ── Draggable divider ── -->
+    <div class="solve-divider" id="solve-divider"></div>
+
+    <!-- ── RIGHT: Code editor ── -->
+    <main class="solve-panel solve-panel--editor">
+
+      <!-- Toolbar -->
+      <div class="solve-editor-toolbar">
+        <select class="solve-lang-select" id="lang-select">
+          <option value="python">Python</option>
+          <option value="java">Java</option>
+          <option value="cpp">C++</option>
+          <option value="javascript">JavaScript</option>
+        </select>
+        <div class="solve-toolbar-actions">
+          <button type="button" class="btn-secondary btn-sm" id="btn-run">▶ Run</button>
+          <button type="button" class="btn-primary btn-sm" id="btn-submit">Submit</button>
+        </div>
+      </div>
+
+      <!-- Code editor -->
+      <div class="solve-editor-wrap">
+        <textarea
+          class="solve-editor"
+          id="code-editor"
+          spellcheck="false"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          placeholder="// Write your solution here…"
+        ></textarea>
+      </div>
+
+      <!-- Output panel (hidden until run/submit) -->
+      <div class="solve-output" id="solve-output" style="display:none;">
+        <div class="solve-output-header">
+          <div style="display:flex; align-items:center; gap:0.75rem;">
+            <span class="solve-output-title">Output</span>
+            <span class="solve-output-status" id="output-status"></span>
+          </div>
+          <button type="button" class="solve-output-close" id="btn-close-output" title="Close">✕</button>
+        </div>
+        <pre class="solve-output-body" id="output-body"></pre>
+      </div>
+
+    </main>
+  </div>
+
+  <!-- Core utilities -->
+  <script src="js/i18n.js"></script>
+  <script src="js/layout.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/api.js"></script>
+  <script src="js/utils.js"></script>
+
+  <!-- Page script -->
+  <script src="js/solve.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add split-screen problem solver page (solve.html) with description panel and code editor, similar to LeetCode
- Add "Start Coding" button on the problems list that navigates to the solver
- Add ability to edit a problem's example from the edit form (single example, matching DB constraint)
- Add PUT /api/problems/{id}/examples endpoint to update examples separately from the main problem fields
- Fix Hibernate instantiation error by adding default constructor to TestCase entity
