### PR TITLE
Github actions workflow deployment flie

### DIFF
--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -1,0 +1,53 @@
+name: Sphinx Docs
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs_sphinx/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build HTML docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Sphinx
+        run: pip install sphinx
+
+      - name: Build docs
+        run: sphinx-build -b html docs_sphinx/source docs_sphinx/build/html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs_sphinx/build/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Created a GitHub Actions workflow (`deploy-docs.yml`) to automatically build the Sphinx HTML documentation on every push to main.
The workflow automatically deploys the compiled HTML outputs from `./build/html` directly to GitHub Pages via the `gh-pages` branch.